### PR TITLE
drop Node.js 4 from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
   - '7'
 script: npm run build


### PR DESCRIPTION
closes #3
